### PR TITLE
Add the MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,26 @@
-PGLiveBackup is released under the MIT license.
+Unless otherwise specified, the code in the repository is available under
+the MIT license.
+
+---
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Maor IT Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Added the actual text of the MIT license, as per the license's terms.

The copyright was assigned to Maor IT Systems as per the information
in http://www.pglivebackup.org/, but this is somewhat speculatory, as
it doesn't explicitly assert this copyright.